### PR TITLE
failsafe and surefire compatible test pattern

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,4 +25,4 @@ jobs:
       uses: EnricoMi/publish-unit-test-result-action@v1
       if: always()
       with:
-        files: "*/target/surefire-reports/*.xml"
+        files: "*/target/*-reports/TEST*.xml"


### PR DESCRIPTION
support failsafe by default ... as some connectors will rely upon selenIde integration test -> executed with failsafe.

... tested this setup on several products and it seems to be fine : for surefire only and failsave only products alike.